### PR TITLE
Fix eas project slug mismatch for preview

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,20 +1,282 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useState, useRef, useEffect } from 'react';
+import { StyleSheet, Text, View, TouchableOpacity, ScrollView, Dimensions, SafeAreaView, Platform } from 'react-native';
+import * as Haptics from 'expo-haptics';
+import DrawingCanvas from './components/DrawingCanvas';
+import NumberTemplate from './components/NumberTemplate';
 
 export default function App() {
+  const [selectedNumber, setSelectedNumber] = useState(1);
+  const [dimensions, setDimensions] = useState(Dimensions.get('window'));
+  const canvasRef = useRef(null);
+
+  const numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+  useEffect(() => {
+    const subscription = Dimensions.addEventListener('change', ({ window }) => {
+      setDimensions(window);
+    });
+    return () => subscription?.remove();
+  }, []);
+
+  const handleClear = () => {
+    if (Platform.OS === 'ios') {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    }
+    if (canvasRef.current) {
+      canvasRef.current.clearCanvas();
+    }
+  };
+
+  const handleNumberSelect = (number) => {
+    if (Platform.OS === 'ios') {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    }
+    setSelectedNumber(number);
+    handleClear();
+  };
+
+  const { width: screenWidth, height: screenHeight } = dimensions;
+  const isLandscape = screenWidth > screenHeight;
+  const isTablet = screenWidth > 768;
+  
+  // iPad向けに最適化されたキャンバスサイズ
+  let canvasSize;
+  if (isTablet) {
+    canvasSize = isLandscape ? Math.min(screenHeight * 0.7, 600) : Math.min(screenWidth * 0.7, 500);
+  } else {
+    canvasSize = Math.min(screenWidth * 0.85, screenHeight * 0.5);
+  }
+
+  if (isLandscape && isTablet) {
+    // iPad横向きレイアウト
+    return (
+      <SafeAreaView style={styles.container}>
+        <StatusBar style="auto" />
+        
+        <View style={styles.landscapeContainer}>
+          <View style={styles.landscapeLeftPanel}>
+            <View style={styles.header}>
+              <Text style={[styles.title, { fontSize: 24 }]}>数字書き取り練習</Text>
+            </View>
+            
+            <ScrollView 
+              showsVerticalScrollIndicator={false}
+              style={styles.numberSelectorVertical}
+              contentContainerStyle={styles.numberSelectorVerticalContent}
+            >
+              {numbers.map((num) => (
+                <TouchableOpacity
+                  key={num}
+                  style={[
+                    styles.numberButton,
+                    selectedNumber === num && styles.selectedNumberButton
+                  ]}
+                  onPress={() => handleNumberSelect(num)}
+                >
+                  <Text style={[
+                    styles.numberButtonText,
+                    selectedNumber === num && styles.selectedNumberButtonText
+                  ]}>
+                    {num}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+            
+            <TouchableOpacity style={[styles.clearButton, { marginTop: 20 }]} onPress={handleClear}>
+              <Text style={styles.clearButtonText}>クリア</Text>
+            </TouchableOpacity>
+          </View>
+          
+          <View style={styles.landscapeRightPanel}>
+            <View style={[styles.canvasContainer, { width: canvasSize, height: canvasSize }]}>
+              <NumberTemplate 
+                number={selectedNumber} 
+                width={canvasSize} 
+                height={canvasSize} 
+              />
+              <DrawingCanvas 
+                ref={canvasRef}
+                width={canvasSize} 
+                height={canvasSize}
+                strokeWidth={10}
+                strokeColor="#2196F3"
+              />
+            </View>
+          </View>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // 通常のレイアウト（縦向きまたはスマートフォン）
   return (
-    <View style={styles.container}>
-      <Text>こんにちは！Cursor 経由の自動PRです 🎯</Text>
+    <SafeAreaView style={styles.container}>
       <StatusBar style="auto" />
-    </View>
+      
+      <View style={styles.header}>
+        <Text style={styles.title}>数字書き取り練習</Text>
+        <Text style={styles.subtitle}>練習したい数字を選んで、なぞってみよう！</Text>
+      </View>
+
+      <ScrollView 
+        horizontal 
+        showsHorizontalScrollIndicator={false}
+        style={styles.numberSelector}
+        contentContainerStyle={styles.numberSelectorContent}
+      >
+        {numbers.map((num) => (
+          <TouchableOpacity
+            key={num}
+            style={[
+              styles.numberButton,
+              selectedNumber === num && styles.selectedNumberButton
+            ]}
+            onPress={() => handleNumberSelect(num)}
+          >
+            <Text style={[
+              styles.numberButtonText,
+              selectedNumber === num && styles.selectedNumberButtonText
+            ]}>
+              {num}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+
+      <View style={styles.canvasWrapper}>
+        <View style={[styles.canvasContainer, { width: canvasSize, height: canvasSize }]}>
+          <NumberTemplate 
+            number={selectedNumber} 
+            width={canvasSize} 
+            height={canvasSize} 
+          />
+          <DrawingCanvas 
+            ref={canvasRef}
+            width={canvasSize} 
+            height={canvasSize}
+            strokeWidth={isTablet ? 10 : 8}
+            strokeColor="#2196F3"
+          />
+        </View>
+      </View>
+
+      <View style={styles.buttonContainer}>
+        <TouchableOpacity style={styles.clearButton} onPress={handleClear}>
+          <Text style={styles.clearButtonText}>クリア</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
+    backgroundColor: '#f5f5f5',
+  },
+  header: {
+    paddingTop: 20,
+    paddingBottom: 10,
     alignItems: 'center',
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 5,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#666',
+  },
+  numberSelector: {
+    maxHeight: 80,
+    marginVertical: 20,
+  },
+  numberSelectorContent: {
+    paddingHorizontal: 20,
+    alignItems: 'center',
+  },
+  numberButton: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: '#fff',
     justifyContent: 'center',
+    alignItems: 'center',
+    marginHorizontal: 8,
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+  },
+  selectedNumberButton: {
+    backgroundColor: '#2196F3',
+    elevation: 4,
+  },
+  numberButtonText: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#333',
+  },
+  selectedNumberButtonText: {
+    color: '#fff',
+  },
+  canvasWrapper: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  canvasContainer: {
+    position: 'relative',
+  },
+  buttonContainer: {
+    paddingHorizontal: 20,
+    paddingBottom: 30,
+    paddingTop: 20,
+  },
+  clearButton: {
+    backgroundColor: '#FF5252',
+    paddingVertical: 15,
+    borderRadius: 10,
+    alignItems: 'center',
+    elevation: 3,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 3,
+  },
+  clearButtonText: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  // 横向きレイアウト用のスタイル
+  landscapeContainer: {
+    flex: 1,
+    flexDirection: 'row',
+  },
+  landscapeLeftPanel: {
+    width: 200,
+    paddingHorizontal: 20,
+    paddingVertical: 20,
+    backgroundColor: '#f0f0f0',
+    alignItems: 'center',
+  },
+  landscapeRightPanel: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  numberSelectorVertical: {
+    flex: 1,
+    marginTop: 20,
+  },
+  numberSelectorVerticalContent: {
+    alignItems: 'center',
+    paddingVertical: 10,
   },
 });

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
     "name": "数字書き取り練習",
-    "slug": "number-writing-practice",
+    "slug": "expo-github-actions-practice",
     "version": "1.0.0",
     "orientation": "default",
     "icon": "./assets/icon.png",

--- a/app.json
+++ b/app.json
@@ -1,9 +1,9 @@
 {
   "expo": {
-    "name": "expo-github-actions-practice",
-    "slug": "expo-github-actions-practice",
+    "name": "数字書き取り練習",
+    "slug": "number-writing-practice",
     "version": "1.0.0",
-    "orientation": "portrait",
+    "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "newArchEnabled": true,

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,9 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      'react-native-reanimated/plugin',
+    ],
+  };
+};

--- a/components/DrawingCanvas.js
+++ b/components/DrawingCanvas.js
@@ -1,0 +1,104 @@
+import React, { useRef, useState, useCallback } from 'react';
+import { View, StyleSheet, Dimensions, PanResponder } from 'react-native';
+import Svg, { Path } from 'react-native-svg';
+
+const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
+
+const DrawingCanvas = React.forwardRef(({ width = screenWidth * 0.8, height = 400, strokeWidth = 3, strokeColor = '#000' }, ref) => {
+  const [paths, setPaths] = useState([]);
+  const [currentPath, setCurrentPath] = useState([]);
+  const [currentColor, setCurrentColor] = useState(strokeColor);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onMoveShouldSetPanResponder: () => true,
+      onPanResponderGrant: (evt) => {
+        const locationX = evt.nativeEvent.locationX;
+        const locationY = evt.nativeEvent.locationY;
+        const newPath = [{ x: locationX, y: locationY }];
+        setCurrentPath(newPath);
+      },
+      onPanResponderMove: (evt) => {
+        const locationX = evt.nativeEvent.locationX;
+        const locationY = evt.nativeEvent.locationY;
+        const updatedPath = [...currentPath, { x: locationX, y: locationY }];
+        setCurrentPath(updatedPath);
+      },
+      onPanResponderRelease: () => {
+        setPaths((prevPaths) => [...prevPaths, { path: currentPath, color: currentColor }]);
+        setCurrentPath([]);
+      },
+    })
+  ).current;
+
+  const createPath = (points) => {
+    if (points.length < 2) return '';
+    
+    let path = `M ${points[0].x},${points[0].y}`;
+    
+    for (let i = 1; i < points.length; i++) {
+      const xMid = (points[i].x + points[i - 1].x) / 2;
+      const yMid = (points[i].y + points[i - 1].y) / 2;
+      path += ` Q ${points[i - 1].x},${points[i - 1].y} ${xMid},${yMid}`;
+    }
+    
+    return path;
+  };
+
+  const clearCanvas = useCallback(() => {
+    setPaths([]);
+    setCurrentPath([]);
+  }, []);
+
+  React.useImperativeHandle(ref, () => ({
+    clearCanvas,
+  }));
+
+  return (
+    <View style={[styles.container, { width, height }]}>
+      <View style={styles.canvasContainer} {...panResponder.panHandlers}>
+        <Svg height={height} width={width}>
+          {paths.map((p, index) => (
+            <Path
+              key={index}
+              d={createPath(p.path)}
+              stroke={p.color}
+              strokeWidth={strokeWidth}
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          ))}
+          <Path
+            d={createPath(currentPath)}
+            stroke={currentColor}
+            strokeWidth={strokeWidth}
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </Svg>
+      </View>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#fff',
+    borderRadius: 10,
+    elevation: 3,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+  },
+  canvasContainer: {
+    flex: 1,
+    backgroundColor: '#fafafa',
+    borderRadius: 10,
+    overflow: 'hidden',
+  },
+});
+
+export default DrawingCanvas;

--- a/components/NumberTemplate.js
+++ b/components/NumberTemplate.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Svg, { Text as SvgText } from 'react-native-svg';
+
+const NumberTemplate = ({ number, width = 300, height = 400 }) => {
+  return (
+    <View style={[styles.container, { width, height }]}>
+      <Svg width={width} height={height}>
+        <SvgText
+          x={width / 2}
+          y={height / 2 + 50}
+          fill="#e0e0e0"
+          fontSize="200"
+          fontWeight="bold"
+          textAnchor="middle"
+          fontFamily="Arial"
+        >
+          {number}
+        </SvgText>
+      </Svg>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    pointerEvents: 'none',
+  },
+});
+
+export default NumberTemplate;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,13 @@
       "version": "1.0.0",
       "dependencies": {
         "expo": "~53.0.20",
+        "expo-haptics": "^14.1.4",
         "expo-status-bar": "~2.2.3",
         "expo-updates": "~0.28.17",
         "react": "19.0.0",
-        "react-native": "0.79.5"
+        "react-native": "0.79.5",
+        "react-native-gesture-handler": "^2.28.0",
+        "react-native-svg": "^15.12.1"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0"
@@ -1390,6 +1393,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@expo/cli": {
       "version": "0.24.20",
       "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.24.20.tgz",
@@ -2429,6 +2444,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2887,6 +2908,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
     },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
@@ -3374,6 +3401,56 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -3453,6 +3530,61 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -3504,6 +3636,18 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-editor": {
@@ -3685,6 +3829,15 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-haptics": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-14.1.4.tgz",
+      "integrity": "sha512-QZdE3NMX74rTuIl82I+n12XGwpDWKb8zfs5EpwsnGi/D/n7O2Jd4tO5ivH+muEG/OCJOMq5aeaVDqqaQOhTkcA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-json-utils": {
@@ -4024,6 +4177,21 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
@@ -4905,6 +5073,12 @@
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ=="
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0"
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -5436,6 +5610,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -6033,10 +6219,40 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
+      "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
       "integrity": "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
+      "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
+      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -7227,6 +7443,12 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/warn-once": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
+      "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==",
+      "license": "MIT"
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "number-writing-practice",
+  "name": "expo-github-actions-practice",
   "displayName": "数字書き取り練習",
   "version": "1.0.0",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "expo-github-actions-practice",
+  "name": "number-writing-practice",
+  "displayName": "数字書き取り練習",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
@@ -10,10 +11,13 @@
   },
   "dependencies": {
     "expo": "~53.0.20",
+    "expo-haptics": "^14.1.4",
     "expo-status-bar": "~2.2.3",
+    "expo-updates": "~0.28.17",
     "react": "19.0.0",
     "react-native": "0.79.5",
-    "expo-updates": "~0.28.17"
+    "react-native-gesture-handler": "^2.28.0",
+    "react-native-svg": "^15.12.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
Implement the number writing practice app with responsive design for iPad and fix the EAS Update slug mismatch.

The EAS Update preview QR code generation failed because the `slug` in `app.json` was `number-writing-practice`, which did not match the EAS project ID (`expo-github-actions-practice`). This PR corrects the `slug` to `expo-github-actions-practice` to enable successful preview generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bd93f33-f5dd-48d3-8165-97c94a02f447">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3bd93f33-f5dd-48d3-8165-97c94a02f447">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>